### PR TITLE
fix incorrect button display in firefox

### DIFF
--- a/plutonium-pagination.html
+++ b/plutonium-pagination.html
@@ -25,7 +25,7 @@
                 /*margin: 0px;*/
                 display: inline-block;
                 position: relative;
-                min-width: fit-content;
+                min-width: max-content;
 
             }
 


### PR DESCRIPTION
Hello! 
I use a component grid pagination version 1.0.3 for vaadin 14 compatibility mode. And I'm find that buttons in firefox browser displayed incorrect, CSS property "min-width: fit-content" don't work. 
So, I suggest fixing it. Also. will be a great that grid pagination release 1.0.3 work with this changes. 

Regards,

Oleg.

<a href="https://ibb.co/z4MNw1S"><img src="https://i.ibb.co/ZMjNC3h/screen-pagination.png" alt="screen-pagination" border="0"></a>